### PR TITLE
Change to line 495: nan array datatype

### DIFF
--- a/rht.py
+++ b/rht.py
@@ -492,7 +492,7 @@ def getData(filepath, make_mask=False, smr=SMR, wlen=WLEN):
     else:
         # Mask Needed, cuts away smr radius from bads, then wlen from bads 
         smr_mask = all_within_diameter_are_good(data, 2*smr+1)
-        nans = np.empty(data.shape, dtype=np.int).fill(np.nan)
+        nans = np.empty(data.shape, dtype=np.float).fill(np.nan)
         wlen_mask = all_within_diameter_are_good( np.where(smr_mask, data, nans), wlen)
         return data, smr_mask, wlen_mask
 


### PR DESCRIPTION
Changed line 495 datatype of array. This line creates an empty array and fills it with nans, but originally the datatype was int and python will not fill an int array with nans so reports an error. I have changed the datatype of the empty array to float so it can be filled with nans.
