### PR TITLE
Script automatically makes output directory if it doesn't exist

### DIFF
--- a/rht.py
+++ b/rht.py
@@ -54,7 +54,7 @@ README = 'README'
 # Output Formatting
 # Directory for RHT output
 OUTPUT = '.'
-if(~ os.path.isdir(OUTPUT)):
+if not os.path.isdir(OUTPUT):
     os.mkdir(OUTPUT)
 
 # Output format is standard fits. In the future we may support saved numpy arrays.

--- a/rht.py
+++ b/rht.py
@@ -54,6 +54,8 @@ README = 'README'
 # Output Formatting
 # Directory for RHT output
 OUTPUT = '.'
+if(~ os.path.isdir(OUTPUT)):
+    os.mkdir(OUTPUT)
 
 # Output format is standard fits. In the future we may support saved numpy arrays.
 xyt_format = '.fits'


### PR DESCRIPTION
Currently, when you put a directory at OUTPUT, and that directory does not yet exist (meaning, you did not make it beforehand), the script returns an error.
With this change, the script will automatically make the output directory if it doesn't exist, and ignore otherwise.