### PR TITLE
Fixing array to be consistent with convRHT.py

### DIFF
--- a/RHT_tools.py
+++ b/RHT_tools.py
@@ -19,7 +19,7 @@ def get_thets(wlen, save = True, returnbins = False, verbose = False):
     thetbins = thetbins - dtheta/2
     
     # thets for plotting
-    thets = np.arange(0, np.pi, dtheta)
+    thets = np.linspace(0.0, np.pi, ntheta, endpoint=False)
     
     if save == True:
         np.save('thets_w'+str(wlen)+'.npy', thets)


### PR DESCRIPTION
For some values of wlen (e.g. 155), using np.arange(0, np.pi, dtheta) returns a different array than using np.linspace(0.0, np.pi, ntheta, endpoint=False) which is used in convRHT.py, since the latter doesn't include the endpoint. Therefore, I'm changing this to be consistent with the array in convRHT.py